### PR TITLE
config: use figment to merge config file with env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "atomic",
  "pear",
  "serde",
+ "toml",
  "uncased",
  "version_check",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ axum-tracing-opentelemetry = "0.18.1"
 bytemuck = "1.16.0"
 bytes = "1.6.0"
 clap = { version = "4.5.4", features = ["derive"] }
-figment = { version = "0.10.19", features = ["env"] }
+figment = { version = "0.10.19", features = ["env", "toml"] }
 openai_dive = { version = "0.4.8", default-features = false, features = ["rustls-tls", "stream", "tokio", "tokio-util"] }
 opentelemetry = { version = "0.23.0", features = ["metrics"] }
 opentelemetry-jaeger-propagator = "0.2.0"


### PR DESCRIPTION
This makes it possible to override the configuration in the TOML config
file with environment variables.

Adding a test for this seems prohibitively difficult, as setting the
environment variable in the build script, or even using Figment's jail
feature, seems to impact the other tests.
